### PR TITLE
Clearer options (Robert Rijkhoff) and typo fix

### DIFF
--- a/src/MainDialog.cpp
+++ b/src/MainDialog.cpp
@@ -5,13 +5,13 @@
 #include <iostream>
 
 MainDialog::MainDialog(QWidget *parent):QDialog(parent),_layout(this) {
-	_options = new QGroupBox(tr("Would you like to keep your system up to date automatically?"));
+	_options = new QGroupBox(tr("Would you like OpenMandriva Lx to update automatically?"));
 	_layout.addWidget(_options);
 
 	QVBoxLayout *optionsLayout = new QVBoxLayout(_options);
-	_configs[0] = new QRadioButton(tr("Do not install updates automatically"), _options);
-	_configs[1] = new QRadioButton(tr("Download updates automatically, install manually"), _options);
-	_configs[2] = new QRadioButton(tr("Download and install updates automatically"), _options);
+	_configs[0] = new QRadioButton(tr("No, do not check nor download updates automatically"), _options);
+	_configs[1] = new QRadioButton(tr("Yes, download updates automatically, but do not install them automatically"), _options);
+	_configs[2] = new QRadioButton(tr("Yes, download and install updates automatically"), _options);
 	for(int i=0; i<3; i++)
 		optionsLayout->addWidget(_configs[i]);
 
@@ -34,7 +34,7 @@ MainDialog::MainDialog(QWidget *parent):QDialog(parent),_layout(this) {
 bool MainDialog::updateConfig(QString config) {
 	QSettings s("/etc/dnf/automatic.conf", QSettings::IniFormat);
 	if(s.isWritable()) {
-		s.setValue("downnload_updates", _configs[0]->isChecked() ? "no" : "yes");
+		s.setValue("download_updates", _configs[0]->isChecked() ? "no" : "yes");
 		s.setValue("apply_updates", _configs[2]->isChecked() ? "yes" : "no");
 	} else
 		return QProcess::execute("/usr/bin/pkexec", QStringList() << "/usr/bin/om-update-config" << config);

--- a/src/MainDialog.cpp
+++ b/src/MainDialog.cpp
@@ -10,7 +10,7 @@ MainDialog::MainDialog(QWidget *parent):QDialog(parent),_layout(this) {
 
 	QVBoxLayout *optionsLayout = new QVBoxLayout(_options);
 	_configs[0] = new QRadioButton(tr("No, do not check nor download updates automatically"), _options);
-	_configs[1] = new QRadioButton(tr("Yes, download updates automatically, but do not install them automatically"), _options);
+	_configs[1] = new QRadioButton(tr("Yes, download updates automatically, but do not install them"), _options);
 	_configs[2] = new QRadioButton(tr("Yes, download and install updates automatically"), _options);
 	for(int i=0; i<3; i++)
 		optionsLayout->addWidget(_configs[i]);


### PR DESCRIPTION
On March 9 2020, Robert Rijkhoff reviewed OMLx 4.1 on DistroWatch and suggested to make the options clearer.
Furthermore while looking at the source I found a typo.
Please review and merge if you like.